### PR TITLE
Include ArrayAccessible class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,6 @@
     "autoload-dev": {
         "psr-4": {
             "DMS\\PHPUnitExtensions\\ArraySubset\\Tests\\": "tests"
-        },
-        "classmap": [
-            "vendor/phpunit/phpunit/tests/"
-        ]
+        }
     }
 }

--- a/src/ArrayAccessible.php
+++ b/src/ArrayAccessible.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace DMS\PHPUnitExtensions\ArraySubset;
+
+use ArrayAccess;
+use ArrayIterator;
+use IteratorAggregate;
+
+class ArrayAccessible implements ArrayAccess, IteratorAggregate
+{
+    private $array;
+
+    public function __construct(array $array = [])
+    {
+        $this->array = $array;
+    }
+
+    public function offsetExists($offset)
+    {
+        return \array_key_exists($offset, $this->array);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        if (null === $offset) {
+            $this->array[] = $value;
+        } else {
+            $this->array[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->array[$offset]);
+    }
+
+    public function getIterator()
+    {
+        return new ArrayIterator($this->array);
+    }
+}

--- a/tests/Unit/Constraint/ArraySubsetTest.php
+++ b/tests/Unit/Constraint/ArraySubsetTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace DMS\PHPUnitExtensions\ArraySubset\Tests\Unit\Constraint;
 
-use ArrayAccessible;
+use DMS\PHPUnitExtensions\ArraySubset\ArrayAccessible;
 use ArrayObject;
 use Countable;
 use DMS\PHPUnitExtensions\ArraySubset\Constraint\ArraySubset;


### PR DESCRIPTION
This helper class was removes in phpunit 9.3 and is required by this
extension.