### PR TITLE
Add support for use with PHPUnit Phar

### DIFF
--- a/src/Constraint/ArraySubset.php
+++ b/src/Constraint/ArraySubset.php
@@ -7,11 +7,13 @@ use ArrayAccess;
 use ArrayObject;
 use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\SebastianBergmann\Comparator\ComparisonFailure as Phar_ComparisonFailure;
 use SebastianBergmann\Comparator\ComparisonFailure;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
 use Traversable;
 
 use function array_replace_recursive;
+use function class_exists;
 use function is_array;
 use function iterator_to_array;
 use function var_export;
@@ -81,7 +83,14 @@ final class ArraySubset extends Constraint
             return null;
         }
 
-        $f = new ComparisonFailure(
+        // Support use of this library when running PHPUnit as a Phar.
+        if (class_exists(Phar_ComparisonFailure::class) === true) {
+            $class = Phar_ComparisonFailure::class;
+        } else {
+            $class = ComparisonFailure::class;
+        }
+
+        $f = new $class(
             $patched,
             $other,
             var_export($patched, true),


### PR DESCRIPTION
When PHPUnit is packaged as a Phar, certain classes are prefixed to prevent conflicts with project dependencies which may use the same files, but in a different version.

For this package, only one referenced class is impacted by this.

The small fix now applied allows for using this package both when running PHPUnit installed via Composer, as well as running Composer installed as a Phar.