### PR TITLE
GH Actions: various workflow tweaks

### DIFF
--- a/.github/workflows/check-cs.yml
+++ b/.github/workflows/check-cs.yml
@@ -27,11 +27,14 @@ jobs:
       with:
         php-version: 7.4
         coverage: none
-        tools: composer
+        tools: composer, cs2pr
 
     - name: Install dependencies
       run: |
         composer update --prefer-dist --no-suggest --no-progress
 
     - name: Check Code Style
-      run: vendor/bin/phpcs
+      run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+
+    - name: Show PHPCS results in PR
+      run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/check-cs.yml
+++ b/.github/workflows/check-cs.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - "*"
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   fix-style:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,10 +21,17 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.x, 7.4, 7.3]
+        php: [8.0, 7.4, 7.3]
         dependency-version: [prefer-lowest, prefer-stable]
+        experimental: [false]
+
+        include:
+          - php: '8.1'
+            dependency-version: 'prefer-stable'
+            experimental: true
 
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
     - name: Checkout code
@@ -37,9 +44,15 @@ jobs:
         coverage: none
         tools: composer
 
-    - name: Install dependencies
+    - name: Install dependencies - normal
+      if: ${{ matrix.php < 8.1 }}
       run: |
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
+
+    - name: Install dependencies - ignore platform reqs
+      if: ${{ matrix.php >= 8.1 }}
+      run: |
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --ignore-platform-reqs
 
     - name: Execute Unit Tests
       run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 7.4, 7.3]
+        php: ['8.0', '7.4', '7.3']
         dependency-version: [prefer-lowest, prefer-stable]
         experimental: [false]
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,8 @@ on:
       - "*"
   schedule:
   - cron: '0 0 * * *'
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
 
 jobs:
   php-tests:


### PR DESCRIPTION
### GH Actions: allow for manually triggering a workflow

Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

This is useful if, for instance, an external action script or composer dependency has broken.
Once a fix is available, failing builds for open PRs can be retriggered manually instead of having to be re-pushed to retrigger the workflow.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/

### GH Actions: report CS violations in the PR

The cs2pr tool will allow to display the results from an action run in checkstyle format in-line in the PR code view, which should improve usability of the workflow results.

Ref: https://github.com/staabm/annotate-pull-request-from-checkstyle

### GH Actions: be explicit about versions and test against 8.1

This adds an "experimental" build against PHP 8.1 as an early detection system for compatibility issues. This build is allowed to fail.

### GH Actions: improve readability of the job title

When the PHP version nr is provided as a string, the full text will show in the `title`, otherwise, for PHP 8.0, it would be cut off to `8` (float to integer cast).
