### PR TITLE
README: clarify code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,20 @@ composer require --dev dms/phpunit-arraysubset-asserts
 
 You have two options to use this in your classes: either directly as a static call or as a trait if you wish to keep existing references working.
 
+### Trait use example
+
 ```php
 <?php
-declare(strict_types=1);
 
-namespace DMS\Tests;
+namespace Your\Package\Tests;
 
-use DMS\PHPUnitExtensions\ArraySubset\Assert;
 use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use PHPUnit\Framework\TestCase;
 
-
-final class AssertTest extends TestCase
+final class ExampleTest extends TestCase
 {
     use ArraySubsetAsserts;
-    
+
     public function testWithTrait(): void
     {
         $expectedSubset = ['bar' => 0];
@@ -39,8 +38,26 @@ final class AssertTest extends TestCase
         $content = ['bar' => '0'];
 
         self::assertArraySubset($expectedSubset, $content, true);
-    }
 
+        $content = ['foo' => '1'];
+
+        $this->assertArraySubset($expectedSubset, $content, true);
+    }
+}
+```
+
+### Static class method example
+
+```php
+<?php
+
+namespace Your\Package\Tests;
+
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
+use PHPUnit\Framework\TestCase;
+
+final class ExampleTest extends TestCase
+{
     public function testWithDirectCall(): void
     {
         $expectedSubset = ['bar' => 0];
@@ -50,5 +67,4 @@ final class AssertTest extends TestCase
         Assert::assertArraySubset($expectedSubset, $content, true);
     }
 }
-
 ```


### PR DESCRIPTION
To use the functionality from the library, users can choose one of two methods to use it.

The existing code example in the readme was confusing as it used both methods in the same example, while at any time, only one method should be used.

This splits out the example into the two distinct usages.

Includes:
* Update namespace in code samples to make it clear that the user namespace is expected.
* Update test class name in code samples to make it clear this is an example.
* Remove `strict_types` declaration.
    While this may just be my opinion, `strict_types` should not be used in test files as it can block the testing of unhappy paths.