### PR TITLE
Allow installation on PHP < 7.3 icw PHPUnit < 9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,11 +21,21 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.0', '7.4', '7.3']
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: ['8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
+        dependency-version: ['prefer-stable']
         experimental: [false]
 
         include:
+          - php: '7.3'
+            dependency-version: 'prefer-lowest'
+            experimental: false
+          - php: '7.4'
+            dependency-version: 'prefer-lowest'
+            experimental: false
+          - php: '8.0'
+            dependency-version: 'prefer-lowest'
+            experimental: false
+
           - php: '8.1'
             dependency-version: 'prefer-stable'
             experimental: true
@@ -43,6 +53,15 @@ jobs:
         php-version: ${{ matrix.php }}
         coverage: none
         tools: composer
+
+    # Remove the coding standards package as it has a higher minimum PHP
+    # requirement and would prevent running the tests on older PHP versions.
+    - name: 'Composer: remove CS dependency'
+      run: composer remove --dev --no-update dms/coding-standard
+
+    - name: 'Composer: update PHPUnit for testing lowest'
+      if: ${{ matrix.dependency-version == 'prefer-lowest' }}
+      run: composer require --no-update phpunit/phpunit:"^9.0"
 
     - name: Install dependencies - normal
       if: ${{ matrix.php < 8.1 }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Simply use it by importing it with Composer
 composer require --dev dms/phpunit-arraysubset-asserts
 ```
 
+> :bulb: The package can be safely required on PHP 5.4 to current in combination with PHPUnit 4.8.36/5.7.21 to current.
+>
+> When the PHPUnit `assertArraySubset()` method is natively available (PHPUnit 4.x - 8.x), the PHPUnit native functionality will be used.
+> For PHPUnit 9 and higher, the extension will kick in and polyfill the functionality which was removed from PHPUnit.
+>
+> Note: PHPUnit 8.x will show deprecation notices about the use of the `assertArraySubset()` method.
+> With this extension in place, those can be safely ignored.
+
+
 ## Usage
 
 You have two options to use this in your classes: either directly as a static call or as a trait if you wish to keep existing references working.

--- a/assertarraysubset-autoload.php
+++ b/assertarraysubset-autoload.php
@@ -31,11 +31,6 @@ if (\class_exists('DMS\PHPUnitExtensions\ArraySubset\Autoload', false) === false
                         // PHPUnit >= 9.0.0.
                         require_once __DIR__ . '/src/ArraySubsetAsserts.php';
 
-                        // Straight away load the other classes needed as well.
-                        // These should only ever be loaded in this context anyway.
-                        require_once __DIR__ . '/src/ArrayAccessible.php';
-                        require_once __DIR__ . '/src/Constraint/ArraySubset.php';
-
                         return true;
                     }
 
@@ -56,6 +51,34 @@ if (\class_exists('DMS\PHPUnitExtensions\ArraySubset\Autoload', false) === false
                     require_once __DIR__ . '/src/AssertFallThrough.php';
 
                     return true;
+
+                /*
+                 * Handle arbitrary additional classes via PSR-4, but only allow loading on PHPUnit >= 9.0.0,
+                 * as additional classes should only ever _need_ to be loaded when using PHPUnit >= 9.0.0.
+                 */
+                default:
+                    if (\method_exists('\PHPUnit\Framework\Assert', 'assertArraySubset') === true) {
+                        // PHPUnit < 9.0.0.
+                        throw new \RuntimeException(
+                            \sprintf(
+                                'Using class "%s" is only supported in combination with PHPUnit >= 9.0.0',
+                                $className
+                            )
+                        );
+                    }
+
+                    // PHPUnit >= 9.0.0.
+                    $file = \realpath(
+                        __DIR__ . \DIRECTORY_SEPARATOR
+                        . 'src' . \DIRECTORY_SEPARATOR
+                        . \strtr(\substr($className, 33), '\\', \DIRECTORY_SEPARATOR) . '.php'
+                    );
+
+                    if (\file_exists($file) === true) {
+                        require_once $file;
+
+                        return true;
+                    }
             }
 
             return false;

--- a/assertarraysubset-autoload.php
+++ b/assertarraysubset-autoload.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace DMS\PHPUnitExtensions\ArraySubset;
+
+if (\class_exists('DMS\PHPUnitExtensions\ArraySubset\Autoload', false) === false) {
+
+    /**
+     * Custom autoloader.
+     *
+     * {@internal The code in this file must be PHP cross-version compatible for PHP 5.4 - current!}
+     */
+    class Autoload
+    {
+        /**
+         * Loads a class.
+         *
+         * @param string $className The name of the class to load.
+         *
+         * @return bool
+         */
+        public static function load($className)
+        {
+            // Only load classes belonging to this library.
+            if (\stripos($className, 'DMS\PHPUnitExtensions\ArraySubset') !== 0) {
+                return false;
+            }
+
+            switch ($className) {
+                case 'DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts':
+                    if (\method_exists('\PHPUnit\Framework\Assert', 'assertArraySubset') === false) {
+                        // PHPUnit >= 9.0.0.
+                        require_once __DIR__ . '/src/ArraySubsetAsserts.php';
+
+                        // Straight away load the other classes needed as well.
+                        // These should only ever be loaded in this context anyway.
+                        require_once __DIR__ . '/src/ArrayAccessible.php';
+                        require_once __DIR__ . '/src/Constraint/ArraySubset.php';
+
+                        return true;
+                    }
+
+                    // PHPUnit < 9.0.0.
+                    require_once __DIR__ . '/src/ArraySubsetAssertsEmpty.php';
+
+                    return true;
+
+                case 'DMS\PHPUnitExtensions\ArraySubset\Assert':
+                    if (\method_exists('\PHPUnit\Framework\Assert', 'assertArraySubset') === false) {
+                        // PHPUnit >= 9.0.0.
+                        require_once __DIR__ . '/src/Assert.php';
+
+                        return true;
+                    }
+
+                    // PHPUnit < 9.0.0.
+                    require_once __DIR__ . '/src/AssertFallThrough.php';
+
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
+    \spl_autoload_register(__NAMESPACE__ . '\Autoload::load');
+}

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "This package provides ArraySubset and related asserts once deprecated in PHPUnit 8",
     "type": "library",
     "require": {
-        "phpunit/phpunit": "^9.0",
-        "php": "^7.3|^7.4|^8.0"
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "php": "^5.4 || ^7.0 || ^8.0"
     },
     "license": "MIT",
     "authors": [
@@ -18,9 +18,7 @@
         "dms/coding-standard": "^8"
     },
     "autoload": {
-        "psr-4": {
-            "DMS\\PHPUnitExtensions\\ArraySubset\\": "src"
-        }
+        "files": ["assertarraysubset-autoload.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e696d445dc2a6b248ffd1acb40a2505",
+    "content-hash": "98ad5ecb92eaf62873a5f73b9800ef28",
     "packages": [
         {
             "name": "doctrine/instantiator",
@@ -2431,7 +2431,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3|^7.4|^8.0"
+        "php": "^5.4 || ^7.0 || ^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -29,6 +29,8 @@
         <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
         <exclude-pattern>src/ArraySubsetAssertsEmpty\.php</exclude-pattern>
         <exclude-pattern>src/AssertFallThrough\.php</exclude-pattern>
+        <exclude-pattern>tests/bootstrap\.php</exclude-pattern>
+        <exclude-pattern>tests/Availability/*\.php</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
         <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
@@ -40,6 +42,7 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
         <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
         <exclude-pattern>src/AssertFallThrough\.php</exclude-pattern>
+        <exclude-pattern>tests/Availability/*\.php</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,7 @@
     <arg name="cache" value=".phpcs.cache" /> <!-- cache the results and don't commit them -->
     <arg value="np" /> <!-- n = ignore warnings, p = show progress -->
 
+    <file>assertarraysubset-autoload.php</file>
     <file>src</file>
     <file>tests</file>
 
@@ -15,6 +16,30 @@
     </rule>
 
     <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators.DisallowedEqualOperator">
-        <exclude-pattern>src/Constraint/ArraySubset.php</exclude-pattern>
+        <exclude-pattern>src/Constraint/ArraySubset\.php</exclude-pattern>
     </rule>
+
+    <!-- BC-layer: exclude rules which would prevent code from being PHP cross-version compatible. -->
+    <rule ref="Squiz.Classes.ClassFileName.NoMatch">
+        <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
+        <exclude-pattern>src/ArraySubsetAssertsEmpty\.php</exclude-pattern>
+        <exclude-pattern>src/AssertFallThrough\.php</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
+        <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
+        <exclude-pattern>src/ArraySubsetAssertsEmpty\.php</exclude-pattern>
+        <exclude-pattern>src/AssertFallThrough\.php</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
+        <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
+        <exclude-pattern>src/AssertFallThrough\.php</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
+        <exclude-pattern>src/AssertFallThrough\.php</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,6 +34,7 @@
     </rule>
     <rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly.ReferenceViaFullyQualifiedName">
         <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>
+        <exclude-pattern>tests/Availability/*\.php</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
         <exclude-pattern>assertarraysubset-autoload\.php</exclude-pattern>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,11 +7,12 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
          beStrictAboutChangesToGlobalState="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <testsuites>
         <testsuite name="unit">
-            <directory>tests</directory>
+            <directory>tests/Availability</directory>
+            <directory phpVersion="7.3.0" phpVersionOperator=">=">tests/Unit</directory>
         </testsuite>
     </testsuites>
 

--- a/src/ArraySubsetAssertsEmpty.php
+++ b/src/ArraySubsetAssertsEmpty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DMS\PHPUnitExtensions\ArraySubset;
+
+/**
+ * ArraySubsetAsserts trait for use with PHPUnit 4.x - 8.x.
+ *
+ * As this trait is empty, calls to `assertArraySubset()` will automatically fall through
+ * to PHPUnit itself and will use the PHPUnit native `assertArraySubset()` method.
+ *
+ * {@internal The code in this file must be PHP cross-version compatible for PHP 5.4 - current!}
+ */
+trait ArraySubsetAsserts
+{
+}

--- a/src/AssertFallThrough.php
+++ b/src/AssertFallThrough.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DMS\PHPUnitExtensions\ArraySubset;
+
+use PHPUnit\Framework\Assert as PhpUnitAssert;
+
+/**
+ * Assert class for use with PHPUnit 4.x - 8.x.
+ *
+ * The method in this class will fall through to PHPUnit itself and use the PHPUnit
+ * native `assertArraySubset()` method.
+ *
+ * {@internal The code in this file must be PHP cross-version compatible for PHP 5.4 - current!}
+ */
+final class Assert
+{
+    /**
+     * Asserts that an array has a specified subset.
+     *
+     * @param array|ArrayAccess|mixed[] $subset
+     * @param array|ArrayAccess|mixed[] $array
+     * @param bool                      $checkForObjectIdentity
+     * @param string                    $message
+     *
+     * @throws ExpectationFailedException
+     * @throws InvalidArgumentException
+     * @throws Exception
+     */
+    public static function assertArraySubset($subset, $array, $checkForObjectIdentity = false, $message = '')
+    {
+        PhpUnitAssert::assertArraySubset($subset, $array, $checkForObjectIdentity, $message);
+    }
+}

--- a/tests/Availability/AutoloadExceptionTest.php
+++ b/tests/Availability/AutoloadExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DMS\PHPUnitExtensions\ArraySubset\Tests\Availibility;
+
+use DMS\PHPUnitExtensions\ArraySubset\Constraint\ArraySubset;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testing that autoloading classes which should only ever be loaded on PHPUnit >= 9 will
+ * generate an exception when attempted on PHPUnit < 9..
+ *
+ * Note: the autoloading in combination with PHPUnit 9+ is automatically tested via the
+ * actual tests for the polyfill as the class will be called upon.
+ *
+ * {@internal The code in this file must be PHP cross-version compatible for PHP 5.4 - current!}
+ *
+ * @requires PHPUnit < 9
+ */
+final class AutoloadExceptionTest extends TestCase
+{
+    public function testAutoloadException()
+    {
+        $expection = '\RuntimeException';
+        $message   = 'Using class "DMS\PHPUnitExtensions\ArraySubset\Constraint\ArraySubset" is only supported in combination with PHPUnit >= 9.0.0';
+
+        if (\method_exists('\PHPUnit\Framework\TestCase', 'expectException') === true) {
+            $this->expectException($expection);
+            $this->expectExceptionMessage($message);
+        } else {
+            $this->setExpectedException($expection, $message);
+        }
+
+        new ArraySubset();
+    }
+}

--- a/tests/Availability/AvailibilityViaClassTest.php
+++ b/tests/Availability/AvailibilityViaClassTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DMS\PHPUnitExtensions\ArraySubset\Tests\Availibility;
+
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testing that the autoloading of the fall-through `Assert` class for PHPUnit 4.x - 8.x works correctly.
+ *
+ * {@internal The code in this file must be PHP cross-version compatible for PHP 5.4 - current!}
+ */
+final class AvailibilityViaClassTest extends TestCase
+{
+    public function testAssertArraySubsetisAvailabe()
+    {
+        Assert::assertArraySubset([1, 2], [1, 2, 3]);
+    }
+}

--- a/tests/Availability/AvailibilityViaTraitTest.php
+++ b/tests/Availability/AvailibilityViaTraitTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DMS\PHPUnitExtensions\ArraySubset\Tests\Availibility;
+
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Testing that the autoloading of the empty `ArraySubsetAsserts` trait for PHPUnit 4.x - 8.x works correctly.
+ *
+ * {@internal The code in this file must be PHP cross-version compatible for PHP 5.4 - current!}
+ */
+final class AvailibilityViaTraitTest extends TestCase
+{
+    use ArraySubsetAsserts;
+
+    public function testAssertArraySubsetisAvailabe()
+    {
+        static::assertArraySubset([1, 2], [1, 2, 3]);
+        $this->assertArraySubset([1, 2], [1, 2, 3]);
+    }
+}

--- a/tests/Unit/AssertTest.php
+++ b/tests/Unit/AssertTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @requires PHPUnit >= 9
+ */
 final class AssertTest extends TestCase
 {
     public function testAssertArraySubsetPassesStrictConfig(): void

--- a/tests/Unit/Constraint/ArraySubsetTest.php
+++ b/tests/Unit/Constraint/ArraySubsetTest.php
@@ -16,6 +16,9 @@ use Traversable;
 
 use function sprintf;
 
+/**
+ * @requires PHPUnit >= 9
+ */
 final class ArraySubsetTest extends TestCase
 {
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * {@internal The code in this file must be PHP cross-version compatible for PHP 5.4 - current!}
+ */
+
+if (defined('__PHPUNIT_PHAR__')) {
+    // Testing via a PHPUnit phar.
+    require_once __DIR__ . '/../assertarraysubset-autoload.php';
+} elseif (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    // Testing via a Composer install.
+    require_once __DIR__ . '/../vendor/autoload.php';
+} else {
+    echo 'Run "composer install" before attempting to run the tests.';
+    exit(1);
+}


### PR DESCRIPTION
## TL;DR:
This PR allows the package to be used with test suites which need to support multiple PHPUnit versions for PHP cross-version compatibility.

* This PR will allow the package to be installed on PHP 5.4 - current in combination with PHPUnit 4.8.36/5.7.21 - current.
* The polyfill provided with the package will only kick in when PHPUnit 9 is detected. On older PHPUnit versions, the package will fall through to using the PHPUnit native functionality.

Includes (availability) tests for the fall throughs.
Includes CI adjustments to safeguard this change.

Fixes #11

_Note: naming is hard, so, I'm happy to adjust the filenames for the fallthrough functionality (or make other adjustments deemed necessary)._


## Commit details

### Add custom autoloader/fall-through to PHPUnit native functionality

This commit:
* Adds a custom autoloader which will either load the polyfills or will load "empty" replacements for the classes in this package which will fall through to using the PHPUnit native functionality for PHPUnit 4.x - 8.x.
* Widens the version requirements for PHP and PHPUnit to allow installing of this package on PHP 5.4 - current in combination with PHPUnit 4.8.36/5.7.21 - current.
* Updates the `autoload` section in the `composer.json` to load the custom autoloader instead of using PSR4 autoloading.
* Makes a few select exceptions to the coding standards for the custom autoloader and the "fall through" files for CS rules which require a higher minimum PHP version.
    - `strict_types` is only available as of PHP 7.0.
    - scalar type declarations and return types are only available as of PHP 7.0, with `void` only being available as of PHP 7.1.
    - Importing functions and constants with `use` statements is only available as of PHP 5.6.
* Updates the README with information about the fact that the package no longer restricts installation to PHPUnit 9.

### Add availability tests for the fall-through functionality

... and run the tests against all PHP versions on which the package can be installed.

This commit:
* Adds a test `bootstrap.php` file which allows for running the tests either via PHPUnit phar files or via a Composer installed version.
* Adds two additional test classes which make sure that the `assertArraySubset()` functionality can be safely used and falls through to the PHPUnit native functionality for PHPUnit < 9.
* Prevents the _real_ unit tests from loading on PHP < 7.3 via an annotation in the `phpunit.xml.dist` file.
    If those files would be loaded on older PHP versions, the test run would break on the parse errors due to modern PHP syntax being used.
* Prevents the _real_ unit tests from running on PHPUnit < 9.
    These tests only need to be run on PHPUnit >= 9 as that is the only time when the polyfills will actually be used.
* Makes a few select exceptions to the coding standards for the new test files for CS rules which require a higher minimum PHP version.

### GH Actions: adjust the test workflow

... to:
* Run the availability tests against all PHP versions on which the package can be installed with `prefer-stable`.
* Run the availability tests as well as the _real_ tests against `lowest` and `stable` for PHPUnit 9 on PHP 7.3 - 8.0.

The test selection is done automatically via the `phpunit.xml.dist` file as adjusted in the previous commit.

As for the running of the _real_ tests against the `lowest` supported PHPUnit 9 version, this requires some tweaking to the workflow script.
As PHPUnit didn't always have an explicit requirement for PHP, running with `prefer-lowest` on PHP 7.3 - 8.0 with the current PHPUnit version constraints would install PHPUnit 4.8.
So, for the `prefer-lowest` runs, we need to make sure that `lowest` is correctly interpreted as "lowest" within the PHPUnit 9.x range.

Also:
* As the coding standards package has a minimum PHP requirement of PHP 7.2, it would block the `composer install` for lower PHP versions to run the tests, so removing the package for this workflow.

### 🆕 Autoloader: add fall-back to PSR4 autoloading 🆕 

This fallback will only allow loading additional files on PHPUnit >= 9.x and will throw an exception otherwise.

Includes dedicated test for the autoload exception.