### PR TITLE
GH Actions: set error reporting to E_ALL + remove cron

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,6 +51,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
+        ini-values: error_reporting=E_ALL, display_errors=On
         coverage: none
         tools: composer
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - "*"
-  schedule:
-  - cron: '0 0 * * *'
   # Allow manually triggering the workflow.
   workflow_dispatch:
 


### PR DESCRIPTION
### GH Actions: set error reporting to E_ALL

Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.

### GH Actions: remove cron schedule

As discussed in #55.

Fixes #55