### PR TITLE
PHP 8.1: fix deprecation notice

### DIFF
--- a/src/ArrayAccessible.php
+++ b/src/ArrayAccessible.php
@@ -6,6 +6,7 @@ namespace DMS\PHPUnitExtensions\ArraySubset;
 use ArrayAccess;
 use ArrayIterator;
 use IteratorAggregate;
+use ReturnTypeWillChange;
 use Traversable;
 
 use function array_key_exists;
@@ -38,6 +39,7 @@ class ArrayAccessible implements ArrayAccess, IteratorAggregate
      *
      * @return mixed
      */
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->array[$offset];


### PR DESCRIPTION
As of PHP 8.1, PHP will start throwing deprecation warnings along the lines of:
```
Deprecated:  Return type of [CLASS]::[METHOD]() should either be compatible with [PHP NATIVE INTERFACE]::[METHOD](): [TYPE], or the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

These type of deprecation notices relate to the [Return types for internal methods RFC](https://wiki.php.net/rfc/internal_method_return_types) in PHP 8.1.

Basically, as of PHP 8.1, these methods in classes which implement PHP native interfaces are expected to have a return type declared.
The return type can be the same as used in PHP itself or a more specific type. This complies with the Liskov principle of covariance, which allows the return type of a child overloaded method to be more specific than that of the parent.

The return type for `ArrayAccess::offsetGet()` is supposed to be `mixed`, but as that is a PHP 8.0 type, it cannot yet be added.
Ref: https://www.php.net/manual/en/class.arrayaccess.php

With that in mind, I've added the annotation instead.

The other methods in this class were already declared with the appropriate return type.

Note: While attributes are a PHP 8.0 feature only, due to the syntax choice for `#[]`, they will ignored in PHP < 8 and can be safely added.