### PR TITLE
GHActions: various updates

### DIFF
--- a/.github/workflows/check-cs.yml
+++ b/.github/workflows/check-cs.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer update --prefer-dist --no-suggest --no-progress
+        composer update --prefer-dist --no-suggest --no-progress --no-interaction
 
     - name: Check Code Style
       run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml

--- a/.github/workflows/check-cs.yml
+++ b/.github/workflows/check-cs.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fix-style:
     name: Fix Code Style

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,12 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   php-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
+        php: ['8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
         dependency-version: ['prefer-stable']
         experimental: [false]
 
@@ -39,8 +39,11 @@ jobs:
           - php: '8.0'
             dependency-version: 'prefer-lowest'
             experimental: false
-
           - php: '8.1'
+            dependency-version: 'prefer-lowest'
+            experimental: false
+
+          - php: '8.2'
             dependency-version: 'prefer-stable'
             experimental: true
 
@@ -69,12 +72,12 @@ jobs:
       run: composer require --no-update phpunit/phpunit:"^9.0" --no-interaction
 
     - name: Install dependencies - normal
-      if: ${{ matrix.php < 8.1 }}
+      if: ${{ matrix.php < 8.2 }}
       run: |
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --no-interaction
 
     - name: Install dependencies - ignore platform reqs
-      if: ${{ matrix.php >= 8.1 }}
+      if: ${{ matrix.php >= 8.2 }}
       run: |
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --ignore-platform-reqs --no-interaction
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,21 +56,21 @@ jobs:
     # Remove the coding standards package as it has a higher minimum PHP
     # requirement and would prevent running the tests on older PHP versions.
     - name: 'Composer: remove CS dependency'
-      run: composer remove --dev --no-update dms/coding-standard
+      run: composer remove --dev --no-update dms/coding-standard --no-interaction
 
     - name: 'Composer: update PHPUnit for testing lowest'
       if: ${{ matrix.dependency-version == 'prefer-lowest' }}
-      run: composer require --no-update phpunit/phpunit:"^9.0"
+      run: composer require --no-update phpunit/phpunit:"^9.0" --no-interaction
 
     - name: Install dependencies - normal
       if: ${{ matrix.php < 8.1 }}
       run: |
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --no-interaction
 
     - name: Install dependencies - ignore platform reqs
       if: ${{ matrix.php >= 8.1 }}
       run: |
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --ignore-platform-reqs
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --ignore-platform-reqs --no-interaction
 
     - name: Execute Unit Tests
       run: vendor/bin/phpunit


### PR DESCRIPTION
### GH Actions: always use --no-interaction for Composer

Adding `--no-interaction` to "plain" Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

### GH Actions: auto-cancel previous builds for same branch

Previously, in Travis, when the same branch was pushed again and the "Auto cancellation" option on the "Settings" page had been turned on (as it was for most repos), any still running builds for the same branch would be stopped in favour of starting the build for the newly pushed version of the branch.

To enable this behaviour in GH Actions, a `concurrency` configuration needs to be added to each workflow for which this should applied to.

More than anything, this is a way to be kind to GitHub by not wasting resources which they so kindly provide to us for free.

Refs:
* https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/
* https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

### GH Actions: update for the release of PHP 8.1

Don't allow PHP 8.1 to fail anymore and start testing against PHP 8.2.