### PR TITLE
GH Actions: fix use of deprecated `set-output`

### DIFF
--- a/.github/workflows/promote-tag.yml
+++ b/.github/workflows/promote-tag.yml
@@ -26,7 +26,7 @@ jobs:
         OUTPUT="${OUTPUT//'%'/'%25'}"
         OUTPUT="${OUTPUT//$'\n'/'%0A'}"
         OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-        echo "::set-output name=body::$OUTPUT"
+        echo "body=$OUTPUT" >> $GITHUB_OUTPUT
     - name: Debug Changelog
       run: echo "Extracted this Changelog \n ${{ steps.changelog.outputs.body }}"
     - uses: ncipollo/release-action@v1


### PR DESCRIPTION
GitHub has deprecated the use of `set-output` (and `set-state`) in favour of new environment files.

This commit updates workflows to use the new methodology.

Refs:
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files