### PR TITLE
GH Actions: update PHP versions in workflows

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
+        php: ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
         dependency-version: ['prefer-stable']
         experimental: [false]
 
@@ -45,8 +45,11 @@ jobs:
           - php: '8.1'
             dependency-version: 'prefer-lowest'
             experimental: false
-
           - php: '8.2'
+            dependency-version: 'prefer-lowest'
+            experimental: false
+
+          - php: '8.3'
             dependency-version: 'prefer-stable'
             experimental: true
 
@@ -79,12 +82,12 @@ jobs:
       run: composer require --no-update phpunit/phpunit:"^9.0" --no-interaction
 
     - name: Install dependencies - normal
-      if: ${{ matrix.php < 8.2 }}
+      if: ${{ matrix.php < 8.3 }}
       run: |
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --no-interaction
 
     - name: Install dependencies - ignore platform reqs
-      if: ${{ matrix.php >= 8.2 }}
+      if: ${{ matrix.php >= 8.3 }}
       run: |
         composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --ignore-platform-reqs --no-interaction
 


### PR DESCRIPTION
PHP 8.2 has been released today :tada: and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Builds against PHP 8.3 are still allowed to fail for now.