### PR TITLE
GH Actions: minor tweaks

### DIFF
--- a/.github/workflows/check-cs.yml
+++ b/.github/workflows/check-cs.yml
@@ -40,7 +40,9 @@ jobs:
         composer update --prefer-dist --no-suggest --no-progress --no-interaction
 
     - name: Check Code Style
+      id: phpcs
       run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
 
     - name: Show PHPCS results in PR
+      if: ${{ always() && steps.phpcs.outcome == 'failure' }}
       run: cs2pr ./phpcs-report.xml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install dependencies - ignore platform reqs
       if: ${{ matrix.php >= 8.3 }}
       run: |
-        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --ignore-platform-reqs --no-interaction
+        composer update --${{ matrix.dependency-version }} --prefer-dist --no-progress --ignore-platform-req=php+ --no-interaction
 
     - name: Execute Unit Tests
       run: vendor/bin/phpunit


### PR DESCRIPTION
### GH Actions: minor tweak

Since Composer 2.2.0, the `--ignore-platform-reqs` setting can be made more specific.

By using `--ignore-platform-req=php+` instead of `--ignore-platform-reqs`, only the upper bound for PHP platform requirements will be ignored, not _all_ platform requirements.

Ref: https://blog.packagist.com/composer-2-2/#-ignore-platform-req-improvements

### GH Actions: harden the workflow against PHPCS ruleset errors

If there is a ruleset error, the `cs2pr` action doesn't receive an `xml` report and exits with a `0` error code, even though the PHPCS run failed (though not on CS errors, but on a ruleset error).

This changes the GH Actions workflow to allow for that situation and still fail the build in that case.