### PR TITLE
Run all unit tests to completion

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,6 +25,7 @@ jobs:
 
     strategy:
       matrix:
+        fail-fast: false
         php: ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4']
         dependency-version: ['prefer-stable']
         experimental: [false]


### PR DESCRIPTION
This setting improves the continuous integration workflow for contributors. Assuming an example where a change would fail in a couple of different combinations of the test matrix:
- Before: only the first affected workflow fails, others are cancelled. Many follow-up attempts may be necessary to find and fix all problems.
- After: all affected workflows fail and indicate problems properly. Calculated action can be taken to fix all issues at once.