### PR TITLE
Add phpunit 11 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests
+name: Tests
 
 on:
   push:
@@ -99,3 +99,139 @@ jobs:
 
     - name: Execute Unit Tests
       run: vendor/bin/phpunit
+
+  test-phar:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          # Test against the high/low supported PHP-PHPUnit combinations.
+
+          # PHPUnit 4 is only supported at the latest version.
+          - php: '5.4'
+            phpunit: '4'
+          - php: '5.5'
+            phpunit: '4'
+
+          # PHPUnit 5 is only supported for PHPUnit 5.7.21-latest.
+          - php: '5.6'
+            phpunit: '5.7.21'
+          - php: '5.6'
+            phpunit: '5'
+          - php: '7.1'
+            phpunit: '5.7.21'
+
+          # PHPUnit 6 is fully supported for the officially supported PHP versions.
+          - php: '7.0'
+            phpunit: '6.4'
+          - php: '7.0'
+            phpunit: '6'
+          - php: '7.2'
+            phpunit: '6.4'
+
+          # PHPUnit 7 is fully supported for the officially supported PHP versions.
+          # Caveats:
+          # - PHPUnit 7.0 seems to have an issue with something related to TestListeners, so using PHPUnit 7.1 instead for "low".
+          # - PHPUnit 7 supports PHP 7.3 as of PHPUnit 7.3.0 (for our purposes).
+          - php: '7.1'
+            phpunit: '7.1'
+          - php: '7.1'
+            phpunit: '7'
+          - php: '7.3'
+            phpunit: '7.3'
+
+          # PHPUnit 8 is fully supported for the officially supported PHP versions.
+          # Caveats:
+          # - PHPUnit 8 supports PHP 8.0 as of PHPUnit 8.5.12 (for our purposes).
+          # - PHPUnit 8 supports PHP 8.1 as of PHPUnit 8.5.19 (for our purposes).
+          # - PHPUnit 8 supports PHP 8.2 as of PHPUnit 8.5.19 (for our purposes).
+          # - PHPUnit 8 supports PHP 8.3 as of PHPUnit 8.5.19 (for our purposes).
+          # - PHPUnit 8 supports PHP 8.4 as of PHPUnit 8.5.40 (for our purposes).
+          - php: '7.2'
+            phpunit: '8'
+          - php: '8.0'
+            phpunit: '8.5.12'
+          - php: '8.4'
+            phpunit: '8.5.40'
+          - php: '8.4'
+            phpunit: '8'
+
+          # PHPUnit 9 is fully supported for the officially supported PHP versions.
+          # Caveats:
+          # - PHPUnit 9 supports PHP 8.0 as of PHPUnit 9.3.0 (for our purposes).
+          # - PHPUnit 9 supports PHP 8.1 as of PHPUnit 9.5.8 (for our purposes).
+          # - PHPUnit 9 supports PHP 8.2 as of PHPUnit 9.5.8 (for our purposes).
+          # - PHPUnit 9 supports PHP 8.3 as of PHPUnit 9.5.8 (for our purposes).
+          # - PHPUnit 9 supports PHP 8.4 as of PHPUnit 9.6.21 (for our purposes).
+          - php: '7.3'
+            phpunit: '9'
+          - php: '8.0'
+            phpunit: '9.3.0'
+          - php: '8.0'
+            phpunit: '9'
+          - php: '8.3'
+            phpunit: '9.5.8'
+          - php: '8.3'
+            phpunit: '9'
+          - php: '8.4'
+            phpunit: '9.6.21'
+
+          # PHPUnit 10 is NOT supported in PHPUnit Polyfills 3.x.
+
+          # PHPUnit 11 is fully supported for the officially supported PHP versions.
+          - php: '8.2'
+            phpunit: '11'
+          - php: '8.3'
+            phpunit: '11.0'
+          - php: '8.4'
+            phpunit: '11.3.6'
+
+          # Experimental builds.
+          - php: 'nightly'
+            phpunit: '9'
+          - php: 'nightly'
+            phpunit: '11'
+
+    name: "PHAR test: PHP ${{ matrix.php }} - PHPUnit: ${{matrix.phpunit}}"
+
+    continue-on-error: ${{ matrix.php == '8.4' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          tools: phpunit:${{ matrix.phpunit }}
+        env:
+          fail-fast: true
+
+      # Remove PHPUnit from the Composer install as we want to be sure the PHAR file is used.
+      - name: 'Composer: remove PHPUnit'
+        run: composer remove phpunit/phpunit --no-update --no-interaction
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
+      - name: Install Composer dependencies - normal
+        if: matrix.php < '8.3'
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--no-dev"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Install Composer dependencies - ignore PHP restrictions
+        if: matrix.php >= '8.3'
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--no-dev --ignore-platform-req=php+"
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
+
+      - name: Run the unit tests
+        if: ${{ ! matrix.coverage }}
+        run: phpunit --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "This package provides ArraySubset and related asserts once deprecated in PHPUnit 8",
     "type": "library",
     "require": {
-        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "php": "^5.4 || ^7.0 || ^8.0"
     },
     "license": "MIT",


### PR DESCRIPTION
Allow for phpunit version 11.* to be used, addressing #85 + _should_ handle the case of https://github.com/rdohms/phpunit-arraysubset-asserts/pull/81/files#r1557304228 so thank you for the suggestion.

Did run the job using `nektos/act` and outside of being ratelimited if I ran several at once, it seemed to generally work. The version constraints can probably be changed a bit though.

Tested with inside a project, which has this composer installed, plus ran tests locally on using a phpunit.phar installation.

Closes #83, #85, #87